### PR TITLE
pass options for get/find into original command

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -1,11 +1,11 @@
 import { formatSelectors } from './lib'
 
 export default function(...args) {
-  const get = (originalFn, selectors) =>
-    originalFn(formatSelectors(selectors, ...args))
+  const get = (originalFn, selectors, options) =>
+    originalFn(formatSelectors(selectors, ...args), options)
 
-  const find = (originalFn, subject, selectors) =>
-    originalFn(subject, formatSelectors(selectors, ...args))
+  const find = (originalFn, subject, selectors, options) =>
+    originalFn(subject, formatSelectors(selectors, ...args), options)
 
   Cypress.Commands.overwrite('get', get)
   Cypress.Commands.overwrite('find', find)


### PR DESCRIPTION
Otherwise e.g. the 'timeout' setting for get/find will be stripped and ignored.